### PR TITLE
Update jasper from 2.0.23 to 2.0.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ ARG JPEG_SHA256=99cb50e48a4556bc571dadd27931955ff458aae32f68c4d9c39d624693f69c32
 # bump: jasper after ./hashupdate Dockerfile JASPER $LATEST
 # bump: jasper link "NEWS" https://github.com/jasper-software/jasper/blob/master/NEWS
 # bump: jasper link "Source diff $CURRENT..$LATEST" https://github.com/jasper-software/jasper/compare/version-$CURRENT..version-$LATEST
-ARG JASPER_VERSION=2.0.23
+ARG JASPER_VERSION=2.0.24
 ARG JASPER_URL="https://github.com/mdadams/jasper/archive/version-$JASPER_VERSION.tar.gz"
-ARG JASPER_SHA256=20facc904bd9d38c20e0c090b1be3ae02ae5b2703b803013be2ecad586a18927
+ARG JASPER_SHA256=d2d28e115968d38499163cf8086179503668ce0d71b90dd33855b3de96a1ca1d
 # bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ https://github.com/webmproject/libwebp.git|*
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
 # bump: libwebp link "Release notes" https://github.com/webmproject/libwebp/releases/tag/v$LATEST


### PR DESCRIPTION
[NEWS](https://github.com/jasper-software/jasper/blob/master/NEWS)  
[Source diff 2.0.23..2.0.24](https://github.com/jasper-software/jasper/compare/version-2.0.23..version-2.0.24)  
