### PR TITLE
Update libwebp from 1.2.0 to 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ ARG JASPER_SHA256=38b8f74565ee9e7fec44657e69adb5c9b2a966ca5947ced5717cde18a7d2ec
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
 # bump: libwebp link "Release notes" https://github.com/webmproject/libwebp/releases/tag/v$LATEST
 # bump: libwebp link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libwebp/compare/v$CURRENT..v$LATEST
-ARG LIBWEBP_VERSION=1.2.0
+ARG LIBWEBP_VERSION=1.2.1
 ARG LIBWEBP_URL="https://github.com/webmproject/libwebp/archive/v$LIBWEBP_VERSION.tar.gz"
-ARG LIBWEBP_SHA256=d60608c45682fa1e5d41c3c26c199be5d0184084cd8a971a6fc54035f76487d3
+ARG LIBWEBP_SHA256=01bcde6a40a602294994050b81df379d71c40b7e39c819c024d079b3c56307f4
 # bump: libtiff /LIBTIFF_VERSION=([\d.]+)/ https://gitlab.com/libtiff/libtiff.git|^4
 # bump: libtiff after ./hashupdate Dockerfile LIBTIFF $LATEST
 # bump: libtiff link "ChangeLog" https://gitlab.com/libtiff/libtiff/-/blob/master/ChangeLog


### PR DESCRIPTION
[Release notes](https://github.com/webmproject/libwebp/releases/tag/v1.2.1)  
[Source diff 1.2.0..1.2.1](https://github.com/webmproject/libwebp/compare/v1.2.0..v1.2.1)  
