### PR TITLE
Update alpine from 3.14.2 to 3.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bump: alpine /FROM alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-FROM alpine:3.14.2 AS builder
+FROM alpine:3.15.0 AS builder
 
 RUN apk add --no-cache \
   coreutils \

--- a/checkelf
+++ b/checkelf
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 NOEXTLIBS=$(test "$(ldd "$1" | wc -l)" -eq 1 && echo yes || echo no)
 RELRO=$(readelf -l "$1" | grep -q GNU_RELRO && echo yes || echo no)


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.15.0-released.html)  
