### PR TITLE
Update libwebp from 1.2.2 to 1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ ARG JASPER_SHA256=38b8f74565ee9e7fec44657e69adb5c9b2a966ca5947ced5717cde18a7d2ec
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
 # bump: libwebp link "Release notes" https://github.com/webmproject/libwebp/releases/tag/v$LATEST
 # bump: libwebp link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libwebp/compare/v$CURRENT..v$LATEST
-ARG LIBWEBP_VERSION=1.2.2
+ARG LIBWEBP_VERSION=1.2.3
 ARG LIBWEBP_URL="https://github.com/webmproject/libwebp/archive/v$LIBWEBP_VERSION.tar.gz"
-ARG LIBWEBP_SHA256=51e9297aadb7d9eb99129fe0050f53a11fcce38a0848fb2b0389e385ad93695e
+ARG LIBWEBP_SHA256=021169407825d7ad918ff4554c6af885e7cf116d9b641cfd7f04c1173ffb9eb0
 # bump: libtiff /LIBTIFF_VERSION=([\d.]+)/ https://gitlab.com/libtiff/libtiff.git|^4
 # bump: libtiff after ./hashupdate Dockerfile LIBTIFF $LATEST
 # bump: libtiff link "ChangeLog" https://gitlab.com/libtiff/libtiff/-/blob/master/ChangeLog


### PR DESCRIPTION
[Release notes](https://github.com/webmproject/libwebp/releases/tag/v1.2.3)  
[Source diff 1.2.2..1.2.3](https://github.com/webmproject/libwebp/compare/v1.2.2..v1.2.3)  
