### PR TITLE
Update x265 to 7afb5179dd9324c9af18deefc96c781cf0710c1f from 3524c32d40fd827d22ce8a89a1a0cddc366d2487

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,8 +208,8 @@ RUN sed -i 's/@LIBS_PRIVATE@/-lstdc++ /' /usr/local/lib/pkgconfig/libde265.pc
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=3524c32d40fd827d22ce8a89a1a0cddc366d2487
-ARG X265_SHA256=e3587bb2e56ddeccceb876ebdf487257fd9bbf169aae5708a0f6dd34baef8f8a
+ARG X265_VERSION=7afb5179dd9324c9af18deefc96c781cf0710c1f
+ARG X265_SHA256=ad2bfbe5e54aa490435c1aa35444cd95afa994d2da88e243673df8379219ebea
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 3524c32d40fd827d22ce8a89a1a0cddc366d2487..7afb5179dd9324c9af18deefc96c781cf0710c1f](https://bitbucket.org/multicoreware/x265_git/branches/compare/7afb5179dd9324c9af18deefc96c781cf0710c1f..3524c32d40fd827d22ce8a89a1a0cddc366d2487#diff)  
