### PR TITLE
Update x265 to 8e821182028cdcc9ad5a089e2d8be7cc96a4a933 from 5a0b22deb6d8adbce8a5d586bcee679eaf45babf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,8 +208,8 @@ RUN sed -i 's/@LIBS_PRIVATE@/-lstdc++ /' /usr/local/lib/pkgconfig/libde265.pc
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=5a0b22deb6d8adbce8a5d586bcee679eaf45babf
-ARG X265_SHA256=4a6afec6a93e7bcc45baa48694af98cd7075c8b44ef11da313aeb8b1e4f46d27
+ARG X265_VERSION=8e821182028cdcc9ad5a089e2d8be7cc96a4a933
+ARG X265_SHA256=5167d58d349fb9c4770be8533ae91e5b3b6f699d0a78dd1b7a908ad476269d86
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 5a0b22deb6d8adbce8a5d586bcee679eaf45babf..8e821182028cdcc9ad5a089e2d8be7cc96a4a933](https://bitbucket.org/multicoreware/x265_git/branches/compare/8e821182028cdcc9ad5a089e2d8be7cc96a4a933..5a0b22deb6d8adbce8a5d586bcee679eaf45babf#diff)  
