### PR TITLE
Update x265 to 26d2bab0063cee453b7d8012e76539a7786c032f from 304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,8 +209,8 @@ RUN sed -i 's/@LIBS_PRIVATE@/-lstdc++ /' /usr/local/lib/pkgconfig/libde265.pc
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b
-ARG X265_SHA256=7fdf307bb14a3cc94a74e6261c8853259a94d1fa0d4454a815e27df4e621cf42
+ARG X265_VERSION=26d2bab0063cee453b7d8012e76539a7786c032f
+ARG X265_SHA256=2233a23b3c45820d2e98285248d4306ad40cd31fd305d67e80823357fd994339
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b..26d2bab0063cee453b7d8012e76539a7786c032f](https://bitbucket.org/multicoreware/x265_git/branches/compare/26d2bab0063cee453b7d8012e76539a7786c032f..304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b#diff)  
