### PR TITLE
Update x265 to 487105dcd21d0f36a7a9e0ec50de85577b9bed04 from 26b387c0148977ec754ca045517b965edf1a9622

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,8 +209,8 @@ RUN sed -i 's/@LIBS_PRIVATE@/-lstdc++ /' /usr/local/lib/pkgconfig/libde265.pc
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=26b387c0148977ec754ca045517b965edf1a9622
-ARG X265_SHA256=f57c98fea6b61e8ad600e342c23df04c1bc659d76b2fc9874c4ece26e741adbe
+ARG X265_VERSION=487105dcd21d0f36a7a9e0ec50de85577b9bed04
+ARG X265_SHA256=f77e093f4fd0a1867bace75357b7844e360b2ce460330558ac4ee85346123fbb
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 26b387c0148977ec754ca045517b965edf1a9622..487105dcd21d0f36a7a9e0ec50de85577b9bed04](https://bitbucket.org/multicoreware/x265_git/branches/compare/487105dcd21d0f36a7a9e0ec50de85577b9bed04..26b387c0148977ec754ca045517b965edf1a9622#diff)  
