### PR TITLE
Update x265 to 7b5332d9df9a26204861009a9d68f28a2898e3ea from 487105dcd21d0f36a7a9e0ec50de85577b9bed04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,8 +209,8 @@ RUN sed -i 's/@LIBS_PRIVATE@/-lstdc++ /' /usr/local/lib/pkgconfig/libde265.pc
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=487105dcd21d0f36a7a9e0ec50de85577b9bed04
-ARG X265_SHA256=f77e093f4fd0a1867bace75357b7844e360b2ce460330558ac4ee85346123fbb
+ARG X265_VERSION=7b5332d9df9a26204861009a9d68f28a2898e3ea
+ARG X265_SHA256=d2f719ae301cd395c918250ea5717c9c19451107f0c29dc19052202db367da52
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 487105dcd21d0f36a7a9e0ec50de85577b9bed04..7b5332d9df9a26204861009a9d68f28a2898e3ea](https://bitbucket.org/multicoreware/x265_git/branches/compare/7b5332d9df9a26204861009a9d68f28a2898e3ea..487105dcd21d0f36a7a9e0ec50de85577b9bed04#diff)  
