### PR TITLE
Update jasper to 4.2.9 from 4.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,9 @@ RUN \
 # bump: jasper after ./hashupdate Dockerfile JASPER $LATEST
 # bump: jasper link "NEWS" https://github.com/jasper-software/jasper/blob/master/NEWS
 # bump: jasper link "Source diff $CURRENT..$LATEST" https://github.com/jasper-software/jasper/compare/version-$CURRENT..version-$LATEST
-ARG JASPER_VERSION=4.2.8
+ARG JASPER_VERSION=4.2.9
 ARG JASPER_URL="https://github.com/mdadams/jasper/archive/version-$JASPER_VERSION.tar.gz"
-ARG JASPER_SHA256=987e8c8b4afcff87553833b6f0fa255b5556a0ecc617b45ee1882e10c1b5ec14
+ARG JASPER_SHA256=b0e5af6b54c274b9670c7e32ddbf6c802d88c896062d760267695dd0aa7014ff
 RUN wget $WGET_OPTS -O jasper.tar.gz "$JASPER_URL"
 RUN echo "$JASPER_SHA256  jasper.tar.gz" | sha256sum --status -c -
 RUN \


### PR DESCRIPTION
[NEWS](https://github.com/jasper-software/jasper/blob/master/NEWS)  
[Source diff 4.2.8..4.2.9](https://github.com/jasper-software/jasper/compare/version-4.2.8..version-4.2.9)  
